### PR TITLE
Improve Makefiles for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,34 @@
 PROGNAME      = precomp
+BZIP2_OBJ     = contrib/bzip2/blocksort.o contrib/bzip2/compress.o contrib/bzip2/decompress.o contrib/bzip2/randtable.o contrib/bzip2/bzlib.o contrib/bzip2/crctable.o contrib/bzip2/huffman.o
+GIFLIB_OBJ    = contrib/giflib/dgif_lib_gcc.o contrib/giflib/egif_lib_gcc.o contrib/giflib/gifalloc.o contrib/giflib/gif_err.o
+PACKJPG_OBJ   = contrib/packjpg/aricoder.o contrib/packjpg/bitops.o contrib/packjpg/packjpg.o
+ZLIB_OBJ      = contrib/zlib/adler32.o contrib/zlib/crc32.o contrib/zlib/zutil.o contrib/zlib/trees.o contrib/zlib/inftrees.o contrib/zlib/inffast.o contrib/zlib/inflate.o contrib/zlib/deflate.o
 CFLAGS        = -DLINUX -D_FILE_OFFSET_BITS=64 -O2 -Wall
-SRC_PACKJPG   = contrib/packjpg/aricoder.cpp contrib/packjpg/bitops.cpp contrib/packjpg/packjpg.cpp
-FLAGS_PACKJPG = -O3 -DUNIX -DBUILD_LIB -Wall -pedantic -funroll-loops -ffast-math -fsched-spec-load -fomit-frame-pointer
-OBJ_ZLIB      = contrib/zlib/adler32.o contrib/zlib/crc32.o contrib/zlib/zutil.o contrib/zlib/trees.o contrib/zlib/inftrees.o contrib/zlib/inffast.o contrib/zlib/inflate.o contrib/zlib/deflate.o
-OBJ_BZIP2     = contrib/bzip2/bzlib.o contrib/bzip2/blocksort.o contrib/bzip2/crctable.o contrib/bzip2/compress.o contrib/bzip2/decompress.o contrib/bzip2/huffman.o contrib/bzip2/randtable.o
-OBJ_GIFLIB    = contrib/giflib/gifalloc.o contrib/giflib/gif_err.o contrib/giflib/dgif_lib_gcc.o contrib/giflib/egif_lib_gcc.o
-OBJECTS       = aricoder.o bitops.o packjpg.o adler32.o crc32.o zutil.o trees.o inftrees.o inffast.o inflate.o deflate.o bzlib.o blocksort.o crctable.o compress.o decompress.o huffman.o randtable.o gifalloc.o gif_err.o dgif_lib_gcc.o egif_lib_gcc.o
 
 .PHONY: all
-all: packjpg $(PROGNAME)
+all: contrib $(PROGNAME)
 
 .PHONY: clean
 clean:
+	make -C contrib/bzip2 clean
+	make -C contrib/giflib clean
+	make -C contrib/packjpg clean
+	make -C contrib/zlib clean
 	rm -f *.o
-	rm -f $(PROGNAME)
 
-$(PROGNAME): $(OBJ_ZLIB) $(OBJ_BZIP2) $(OBJ_GIFLIB) $(OBJ_PACKJPG)
-	g++ $(CFLAGS) $(OBJECTS) precomp.cpp -s -oprecomp
+bzip2:
+	make -C contrib/bzip2
 
-packjpg: $(SRC_PACKJPG)
-	g++ -c $(FLAGS_PACKJPG) $(SRC_PACKJPG)
+giflib:
+	make -C contrib/giflib
 
-%.o: %.c
-	gcc -g -c $(CFLAGS) $<
+packjpg:
+	make -C contrib/packjpg
+
+zlib:
+	make -C contrib/zlib
+
+contrib: bzip2 giflib packjpg zlib
+
+$(PROGNAME): contrib
+	g++ $(CFLAGS) $(GIFLIB_OBJ) $(PACKJPG_OBJ) $(BZIP2_OBJ) $(ZLIB_OBJ) precomp.cpp -s -oprecomp

--- a/contrib/bzip2/Makefile
+++ b/contrib/bzip2/Makefile
@@ -1,0 +1,12 @@
+OBJECTS = bzlib.o blocksort.o crctable.o compress.o decompress.o huffman.o randtable.o
+CFLAGS  = -DLINUX -D_FILE_OFFSET_BITS=64 -O2 -Wall
+
+.PHONY: all
+all: $(OBJECTS)
+
+.PHONY: clean
+clean:
+	rm -f *.o
+
+%.o: %.c
+	gcc -g -c $(CFLAGS) $<

--- a/contrib/giflib/Makefile
+++ b/contrib/giflib/Makefile
@@ -1,0 +1,12 @@
+OBJECTS = gifalloc.o gif_err.o dgif_lib_gcc.o egif_lib_gcc.o
+CFLAGS  = -DLINUX -D_FILE_OFFSET_BITS=64 -O2 -Wall
+
+.PHONY: all
+all: $(OBJECTS)
+
+.PHONY: clean
+clean:
+	rm -f *.o
+
+%.o: %.c
+	gcc -g -c $(CFLAGS) $<

--- a/contrib/packjpg/Makefile
+++ b/contrib/packjpg/Makefile
@@ -1,0 +1,12 @@
+OBJECTS = bitops.o aricoder.o packjpg.o
+CFLAGS  = -O3 -DUNIX -DBUILD_LIB -Wall -pedantic -funroll-loops -ffast-math -fsched-spec-load -fomit-frame-pointer
+
+.PHONY: all
+all: $(OBJECTS)
+
+.PHONY: clean
+clean:
+	rm -f *.o
+
+%.o: %.cpp
+	g++ -c $(CFLAGS) $<

--- a/contrib/zlib/Makefile
+++ b/contrib/zlib/Makefile
@@ -1,0 +1,12 @@
+OBJECTS = adler32.o crc32.o zutil.o trees.o inftrees.o inffast.o inflate.o deflate.o
+CFLAGS  = -DLINUX -D_FILE_OFFSET_BITS=64 -O2 -Wall
+
+.PHONY: all
+all: $(OBJECTS)
+
+.PHONY: clean
+clean:
+	rm -f *.o
+
+%.o: %.c
+	gcc -g -c $(CFLAGS) $<


### PR DESCRIPTION
Add a set of individual Makefiles for all contrib libs and modify the main Makefile to make use of those. This is a much cleaner and less complex way to build things.