### PR TITLE
Change Makefiles to be compatible with non-GCC platforms (e.g. FreeBSD)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ liblzma:
 contrib: bzip2 giflib packjpg packmp3 zlib liblzma
 
 $(PROGNAME): contrib
-	g++ $(CFLAGS) $(GIFLIB_OBJ) $(PACKJPG_OBJ) $(PACKMP3_OBJ) $(BZIP2_OBJ) $(ZLIB_OBJ) $(LIBLZMA_OBJ) $(LIBLZMA_CPP) precomp.cpp -s -oprecomp
+	c++ $(CFLAGS) $(GIFLIB_OBJ) $(PACKJPG_OBJ) $(PACKMP3_OBJ) $(BZIP2_OBJ) $(ZLIB_OBJ) $(LIBLZMA_OBJ) $(LIBLZMA_CPP) precomp.cpp -s -oprecomp

--- a/contrib/liblzma/Makefile
+++ b/contrib/liblzma/Makefile
@@ -10,4 +10,4 @@ clean:
 	rm -f *.o
 
 liblzma:
-	gcc $(CFLAGS) $(LIBLZMA_INCLUDES) $(LIBLZMA_C)
+	cc $(CFLAGS) $(LIBLZMA_INCLUDES) $(LIBLZMA_C)


### PR DESCRIPTION
Tested successfully on FreeBSD 11.1-RELEASE and Arch Linux Nov. 10.