### PR TITLE
preflate: allow decoding of degenerate single-code Huffman codings

### DIFF
--- a/contrib/preflate/support/huffman_helper.cpp
+++ b/contrib/preflate/support/huffman_helper.cpp
@@ -70,5 +70,6 @@ bool HuffmanHelper::countSymbols(
   }
 
   // Check that we don't have holes
-  return nextCode[maxLength] + blCount[maxLength] == (unsigned)(1 << (maxLength - 1));
+  unsigned codeCheck = nextCode[maxLength] + blCount[maxLength];
+  return codeCheck == (unsigned)(1 << (maxLength - 1)) || codeCheck == 1 && maxLength == 2;
 }


### PR DESCRIPTION
See: https://cs.opensource.google/go/go/+/e7c56fe9948449a3710b36c22c02d57c215d1c10:src/compress/flate/inflate.go;l=167

Fixes #126
