### PR TITLE
Include assert.h in range_encoder.h

### DIFF
--- a/contrib/liblzma/rangecoder/range_encoder.h
+++ b/contrib/liblzma/rangecoder/range_encoder.h
@@ -14,6 +14,7 @@
 #ifndef LZMA_RANGE_ENCODER_H
 #define LZMA_RANGE_ENCODER_H
 
+#include <assert.h>
 #include "range_common.h"
 #include "price.h"
 


### PR DESCRIPTION
Building `precomp` on MacOS Sonoma leads to the following error

```
precomp-cpp-0.4.7/contrib/liblzma/rangecoder/range_encoder.h:153:2: error: call to undeclared function 'assert'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        assert(rc->count <= RC_SYMBOLS_MAX);
        ^
```

This PR fixes the issue by adding `#include <assert.h>` in `range_encoder.h`.